### PR TITLE
Accessible ReportGenerator form

### DIFF
--- a/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/statistics/ReportGenerator.java
+++ b/dspace-xmlui/dspace-xmlui-api/src/main/java/org/dspace/app/xmlui/aspect/statistics/ReportGenerator.java
@@ -71,10 +71,10 @@ public class ReportGenerator
      * The minimum date for the from or to field to be. (e.g. The beginning of DSpace)
      */
     private static String MINIMUM_DATE = "2008-01-01";
-    private static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    private static SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy");
 
     // perfect input is 2008-01-22, an alternate format is 01/22/2008
-    static String[] formatStrings = {"yyyy-MM-dd", "MM/dd/yyyy"};
+    static String[] formatStrings = {"MM/dd/yyyy", "yyyy-MM-dd"};
 
     private Map<String, String> params;
     
@@ -165,13 +165,13 @@ public class ReportGenerator
             setDateStart();
             Text from = reportForm.addText("from", "slick");
             from.setLabel("From");
-            from.setHelp("The start date of the report, ex 2008-01-01");
+            from.setHelp("The start date of the report, ex 01/31/2008");
             from.setValue(getDateStartFormated());
 
             setDateEnd();
             Text to = reportForm.addText("to", "slick");
             to.setLabel("To");
-            to.setHelp("The end date of the report, ex 2010-12-31");
+            to.setHelp("The end date of the report, ex 12/31/2012");
             to.setValue(getDateEndFormatted());
 
             //Add whether it is fiscal or not
@@ -204,7 +204,7 @@ public class ReportGenerator
 
             //Create dateValidator and min and max dates
             DateValidator dateValidator = new DateValidator(false, DateFormat.SHORT);
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy");
 
             Date maximumDate = new Date();
             Date minimumDate = dateFormat.parse(ReportGenerator.MINIMUM_DATE);

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/dashboard/lib/report-generator-mod.js
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/dashboard/lib/report-generator-mod.js
@@ -1,9 +1,6 @@
 // # ReportGenerator Js Mod
-// ## Addes jQuery functionality to the ReportGenerator
+// ## Addes jQuery datepicker functionality to the ReportGenerator
 
-// Disable the date-picker because it shows mal-formatted dates. we can re-enable when:
-// - it shows dates like 2008-03-24
-// - a user can easily adjust a date manually
-//jQuery(function ($) {
-//  $(".date-picker").datepicker();
-//});
+jQuery(function ($) {
+  $(".date-picker").datepicker({dateFormat: "mm/dd/yy"});
+});


### PR DESCRIPTION
It's time to merge in the datepicker!

I made the necessary changes to make the ReportGenerator use the new date format "MM/dd/yyyy" and I uncommented the call to the accessible jQuery datepicker. I tested on a few different pages and it seems to work fine.

I also rebased report-generator-mod with kb-source-sandbox so the merge will be as clean as possible.
