### PR TITLE
Merge in disabled themes for audio player and realPlayer based on dc.source.uri

### DIFF
--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/realplayer/lib/style-ie.css
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/realplayer/lib/style-ie.css
@@ -1,0 +1,9 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/realplayer/lib/style.css
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/realplayer/lib/style.css
@@ -1,0 +1,16 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+
+
+
+
+
+
+
+
+

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/realplayer/realplayer.xsl
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/realplayer/realplayer.xsl
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The contents of this file are subject to the license and copyright
+    detailed in the LICENSE and NOTICE files at the root of the source
+    tree and available online at
+
+    http://www.dspace.org/license/
+
+-->
+
+
+<xsl:stylesheet xmlns:i18n="http://apache.org/cocoon/i18n/2.1"
+	xmlns:dri="http://di.tamu.edu/DRI/1.0/"
+	xmlns:mets="http://www.loc.gov/METS/"
+	xmlns:xlink="http://www.w3.org/TR/xlink/"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+	xmlns:dim="http://www.dspace.org/xmlns/dspace/dim"
+	xmlns:xhtml="http://www.w3.org/1999/xhtml"
+	xmlns:mods="http://www.loc.gov/mods/v3"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns="http://www.w3.org/1999/xhtml"
+	exclude-result-prefixes="i18n dri mets xlink xsl dim xhtml mods dc">
+    
+    <xsl:import href="../dri2xhtml.xsl"/>
+    <xsl:output indent="yes"/>
+    
+
+<!-- for realplayer theme, we remove the file list from simple item view -->
+
+    <!-- An item rendered in the summaryView pattern. This is the default way to view a DSpace item in Manakin. -->
+    <xsl:template name="itemSummaryView-DIM">
+        <!-- Generate the info about the item from the metadata section -->
+        <xsl:apply-templates select="./mets:dmdSec/mets:mdWrap[@OTHERMDTYPE='DIM']/mets:xmlData/dim:dim"
+        mode="itemSummaryView-DIM"/>
+
+        <!-- Generate the Creative Commons license information from the file section (DSpace deposit license hidden by default)-->
+        <xsl:apply-templates select="./mets:fileSec/mets:fileGrp[@USE='CC-LICENSE']"/>
+
+    </xsl:template>
+
+
+<!-- for realplayer theme, add the player. -->
+
+    <!-- Generate the info about the item from the metadata section -->
+    <xsl:template match="dim:dim" mode="itemSummaryView-DIM">
+
+        <xsl:choose>
+            <xsl:when test="count(dim:field[@element='source'][@qualifier='uri']) &gt; 0">
+                <xsl:for-each select="dim:field[@element='source'][@qualifier='uri']">
+                    <xsl:variable name="sourceURI">
+                        <xsl:value-of select="./node()"/>
+                    </xsl:variable>
+
+		    <embed console="RealPlayer" controls="All" height="100" width="375" type="audio/x-pn-realaudio-plugin" autostart="true">
+                       	<xsl:attribute name="src">
+	                    <xsl:value-of select="$sourceURI" />
+        	        </xsl:attribute>
+		    </embed>
+		    <br />
+                    <p>Requires RealPlayer to view. If the player does not automatically load, try clicking 
+                        <a>
+                            <xsl:attribute name="href">
+                                <xsl:value-of select="$sourceURI" />
+                            </xsl:attribute>
+                            <xsl:text>here</xsl:text>
+                        </a> instead.
+                    </p>
+                </xsl:for-each>
+            </xsl:when>
+        </xsl:choose>
+
+        <table class="ds-includeSet-table">
+            <xsl:call-template name="itemSummaryView-DIM-fields">
+            </xsl:call-template>
+        </table>
+        <xsl:if test="$config-use-COinS = 1">
+            <!--  Generate COinS  -->
+            <span class="Z3988">
+                <xsl:attribute name="title">
+                    <xsl:call-template name="renderCOinS"/>
+                </xsl:attribute>
+                &#xFEFF; <!-- non-breaking space to force separating the end tag -->
+            </span>
+        </xsl:if>
+
+        <!-- bds: this seemed as appropriate a place as any to throw in the blanket copyright notice -->
+        <!--        see also match="dim:dim" mode="itemDetailView-DIM"  -->
+        <p class="copyright-text">Items in Knowledge Bank are protected by copyright, with all rights reserved, unless otherwise indicated.</p>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/realplayer/sitemap.xmap
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/realplayer/sitemap.xmap
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	sitemap.xmap
+	
+	Version: $Revision$
+	
+	Date: $Date$
+	
+	Copyright (c) 2002-2005, Hewlett-Packard Company and Massachusetts
+	Institute of Technology.  All rights reserved.
+	
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are
+	met:
+	
+	- Redistributions of source code must retain the above copyright
+	notice, this list of conditions and the following disclaimer.
+	
+	- Redistributions in binary form must reproduce the above copyright
+	notice, this list of conditions and the following disclaimer in the
+	documentation and/or other materials provided with the distribution.
+	
+	- Neither the name of the Hewlett-Packard Company nor the name of the
+	Massachusetts Institute of Technology nor the names of their
+	contributors may be used to endorse or promote products derived from
+	this software without specific prior written permission.
+	
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+	OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+	ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+	TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+	USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+	DAMAGE.
+-->
+<map:sitemap xmlns:map="http://apache.org/cocoon/sitemap/1.0">
+	<map:pipelines>
+		
+		<!-- 
+			Define global theme variables that are used later in this 
+			sitemap. Two variables are typically defined here, the theme's 
+			path and name. The path is the directory name where this theme 
+			is located, such as "Reference" for the reference theme. The 
+			theme's name is used only for descriptive purposes to describe 
+			the theme.		
+		-->
+		<map:component-configurations>
+			<global-variables>
+				<theme-path>realplayer</theme-path>
+				<theme-name>Embed Real player to play streaming from dc.source.uri</theme-name>
+			</global-variables>
+		</map:component-configurations>
+		
+		
+		<map:pipeline>
+			<!-- Allow the browser to cache static content for an hour -->
+			<map:parameter name="expires" value="access plus 1 hours"/>
+			
+			<!-- Static content -->
+			<map:match pattern="themes/*/**">
+				<map:read src="{2}"/>
+			</map:match>
+		</map:pipeline>
+		
+		<!-- 
+			The theme's pipeline is used to process all requests handled 
+			by the theme. It is broken up into two parts, the first part 
+			handles all static theme content while the second part handle 
+			all dynamic aspect generated content. The static content is 
+			such things as stylesheets, images, or static pages. Typically 
+			these are just stored on disk and passed directly to the 
+			browser without any processing. 
+		-->
+		<map:pipeline>
+			<!-- Never allow the browser to cache dynamic content -->
+			<map:parameter name="expires" value="now"/>
+			
+			<!-- Aspect content 
+			
+			There are five steps to processing aspect content:
+				
+			1: Generate the DRI page
+				
+				The first step is to generate a DRI page for the request; 
+				this is handled by the aspect chain. Once it is generated 
+				it is the beginning of a theme's pipeline, the DRI page is 
+				ultimately transformed in the resulting XHTML that is 
+				given to the user's browser.
+				
+			2: Add page metadata
+				
+				The next step is to add theme specific metadata to the 
+				DRI page. This is metadata about where the theme is 
+				located and its name. Typically this metadata is different 
+				depending on the users browser, this allows us to give 
+				different stylesheets to Internet Explorer than for other 
+				browsers.
+				
+			3: Transform to XHTML
+				
+				The third step is the main component of a theme the XSL 
+				transformations will turn the DRI page from the aspects 
+				into an XHTML page useable by browsers. 
+				
+			4: Localize the page
+				
+				The second to last step is to localize the content for the 
+				particular user, if they user is requesting a page in a 
+				particular language then those language strings are inserted 
+				into the resulting XHTML.  
+				
+			5: Serialize to the browser
+				
+				The last step sends the page to the user's browser. 
+				
+			-->
+			<map:match pattern="**">
+				
+				<!-- Step 1: Generate the DRI page -->
+				<map:generate type="file" src="cocoon://DRI/{1}"/>
+				
+				<!-- Step 2 Add page metadata -->
+				<map:select type="browser">
+					<map:when test="explorer">
+						<map:transform type="IncludePageMeta">
+							<map:parameter name="stylesheet.screen#1" value="lib/style.css"/>
+							<map:parameter name="stylesheet.screen#2" value="lib/style-ie.css"/>
+							
+							<map:parameter name="theme.path" value="{global:theme-path}"/>
+							<map:parameter name="theme.name" value="{global:theme-name}"/>
+						</map:transform>
+					</map:when>
+					<map:otherwise>
+						<map:transform type="IncludePageMeta">
+							<map:parameter name="stylesheet.screen" value="lib/style.css"/>
+							
+							<map:parameter name="theme.path" value="{global:theme-path}"/>
+							<map:parameter name="theme.name" value="{global:theme-name}"/>
+						</map:transform>
+					</map:otherwise>
+				</map:select>
+				
+				<!-- Debuging output -->
+				<map:match type="request" pattern="XML">
+					<map:serialize type="xml"/>
+				</map:match>
+				
+				<!-- Step 3: Transform to XHTML -->
+				<map:transform src="{global:theme-path}.xsl"/>
+			    <!-- <map:transform src="template.xsl"/> -->
+				
+				<!-- Step 4: Localize the page -->
+				<map:act type="locale">
+					<map:transform type="i18n">
+						<map:parameter name="locale" value="{locale}"/>						
+					</map:transform>
+				</map:act>
+				
+				<!-- Step 5: Serialize to the browser -->
+				<map:serialize type="xhtml"/>
+				
+			</map:match>
+		</map:pipeline>
+	</map:pipelines>
+</map:sitemap>

--- a/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/snazy/snazy.xsl
+++ b/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/themes/snazy/snazy.xsl
@@ -265,4 +265,51 @@
             </div>
         </li>
     </xsl:template>
+
+    <!-- Generate the info about the item from the metadata section -->
+    <xsl:template match="dim:dim" mode="itemSummaryView-DIM">
+
+        <xsl:choose>
+            <xsl:when test="count(dim:field[@element='source'][@qualifier='uri']) &gt; 0">
+                <h3>Embed Source.URI Media</h3>
+                <xsl:for-each select="dim:field[@element='source'][@qualifier='uri']">
+                    <xsl:variable name="sourceURI">
+                        <xsl:value-of select="./node()"/>
+                    </xsl:variable>
+
+                    <embed class="googleplayer" type="application/x-shockwave-flash" wmode="transparent" height="27" width="320">
+                        <xsl:attribute name="src">
+                            <xsl:text>http://www.google.com/reader/ui/3523697345-audio-player.swf?audioUrl=</xsl:text>
+                            <xsl:value-of select="$sourceURI" />
+                        </xsl:attribute>
+                    </embed>
+                    <a>
+                        <xsl:attribute name="href">
+                            <xsl:value-of select="$sourceURI" />
+                        </xsl:attribute>
+                        <xsl:text>View this in your browser.</xsl:text>
+                    </a>
+                </xsl:for-each>
+            </xsl:when>
+        </xsl:choose>
+
+        <table class="ds-includeSet-table">
+            <xsl:call-template name="itemSummaryView-DIM-fields">
+            </xsl:call-template>
+        </table>
+        <xsl:if test="$config-use-COinS = 1">
+            <!--  Generate COinS  -->
+            <span class="Z3988">
+                <xsl:attribute name="title">
+                    <xsl:call-template name="renderCOinS"/>
+                </xsl:attribute>
+                &#xFEFF; <!-- non-breaking space to force separating the end tag -->
+            </span>
+        </xsl:if>
+
+        <!-- bds: this seemed as appropriate a place as any to throw in the blanket copyright notice -->
+        <!--        see also match="dim:dim" mode="itemDetailView-DIM"  -->
+        <p class="copyright-text">Items in Knowledge Bank are protected by copyright, with all rights reserved, unless otherwise indicated.</p>
+    </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Some old branches in the code referred to an audio player within the snazy theme, and a realplayer theme. These aren't used or referred to anywhere, so merging them in will not break anything. Since they appear to work based on various content in a dc.source.uri, they could be useful if enabled selectively.
